### PR TITLE
fix(recipes): add missing profession info to nylon futon bed

### DIFF
--- a/src/data/recipes.json
+++ b/src/data/recipes.json
@@ -26789,7 +26789,13 @@
     "time": 6.0,
     "calories": 180.0,
     "table": "Advanced Tailoring Table",
-    "professions": []
+    "professions": [
+      {
+        "name": "TailoringSkill",
+        "displayName": "Tailoring",
+        "level": 6
+      }
+    ]
   },
   {
     "name": "Nylon Futon Couch",


### PR DESCRIPTION
This recipe is missing profession info and displays the price as zero.
Thanks for the tool by the way!